### PR TITLE
feat: add Instagram reels and YouTube shorts processing support

### DIFF
--- a/handlers/messages.py
+++ b/handlers/messages.py
@@ -3,7 +3,8 @@ from urllib.parse import urlparse
 
 from telegram import Update
 from telegram.ext import ContextTypes
-from services import tiktok
+
+from services import tiktok, ydl
 from services.exceptions import VideoUnavailable
 from utils.logger import setup_logger
 
@@ -11,6 +12,8 @@ logger = setup_logger()
 
 SERVICE_HANDLERS = {
     "tiktok": tiktok.process,
+    "instagram": ydl.process,
+    "youtu": ydl.process,
 }
 
 async def link(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -37,6 +40,7 @@ async def link(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if not handler:
         logger.error(f"Unsupported URL: {video_url}")
+        await message.reply_text("Unsupported URL 😔")
         return
 
     try:
@@ -45,8 +49,7 @@ async def link(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if media_group:
             await message.reply_media_group(media=media_group)
         else:
-            await message.reply_text("😔 Could not extract any media from the link")
-
+            await message.reply_text("Could not extract any media from the link 😔")
     except VideoUnavailable:
         await message.reply_text("❌ Video unavailable")
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+yt-dlp
 python-telegram-bot~=22.3
 httpx~=0.28.1
 dotenv~=0.9.9

--- a/services/tiktok.py
+++ b/services/tiktok.py
@@ -10,7 +10,7 @@ logger = setup_logger()
 BASE_API_URL = f"https://douyin.wtf/api/hybrid/video_data?url="
 
 async def process(url: str) -> None | list[InputMedia]:
-    logger.info(f"Processing tiktok url: {url}")
+    logger.info(f"Processing Tiktok url: {url}")
 
     if "deleted" in url or "private" in url:
         raise VideoUnavailable("Video unavailable")

--- a/services/ydl.py
+++ b/services/ydl.py
@@ -1,0 +1,34 @@
+import yt_dlp
+from telegram import InputMediaVideo
+from utils.logger import setup_logger
+
+logger = setup_logger()
+
+ydl_opts = {
+    'noplaylist': True,
+    'quiet': True,
+}
+
+async def process(url: str) -> list[InputMediaVideo] | None:
+    logger.info(f"Extracting info for URL: {url}")
+    direct_url = None
+
+    try:
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            info = ydl.extract_info(url, download=False)
+
+            for f in reversed(info['formats']):
+                if f.get('vcodec') != 'none' and f.get('acodec') != 'none' and f.get('url'):
+                    logger.info(f"Found suitable pre-merged format: {f.get('format_id')} at {f.get('height')}p")
+                    direct_url = f['url']
+                    break
+
+            if direct_url:
+                return [InputMediaVideo(media=direct_url)]
+            else:
+                logger.warning("No pre-merged video format found for this URL")
+                return None
+
+    except Exception as e:
+        logger.error(f"Failed to process Instagram URL {url}: {e}")
+        return None


### PR DESCRIPTION
pull request adds support for processing Instagram and YouTube video links using a new handler based on `yt_dlp`