### PR TITLE
fix: enable concurrent updates and improve Instagram media processing

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -12,7 +12,7 @@ commands = {
 }
 
 def main():
-    bot = Application.builder().token(BOT_TOKEN).build()
+    bot = Application.builder().token(BOT_TOKEN).concurrent_updates(True).build()
 
     for command, handler in commands.items():
         bot.add_handler(CommandHandler(command, handler))

--- a/services/instagram.py
+++ b/services/instagram.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from instagrapi import Client
 from telegram import InputMedia, InputMediaPhoto, InputMediaVideo
 
@@ -13,8 +15,8 @@ async def process(url: str) -> None | list[InputMedia]:
     logger.info(f"Processing Instagram url: {url}")
 
     try:
-        media_id = cl.media_pk_from_url(url)
-        media_info = cl.media_info_v1(media_id)
+        media_id = await asyncio.to_thread(cl.media_pk_from_url, url)
+        media_info = await asyncio.to_thread(cl.media_info_v1, media_id)
         if not media_info:
             logger.warning(f"No media found for url: {url}")
             return None


### PR DESCRIPTION
* Enabled concurrent updates in the Telegram bot by passing `.concurrent_updates(True)` 
* Imported the `asyncio` module in `services/instagram.py` to support asynchronous operations