### PR TITLE
fix: resolve share links and handle media not found errors in Instagr…

### DIFF
--- a/services/instagram.py
+++ b/services/instagram.py
@@ -21,8 +21,8 @@ async def process(url: str) -> None | list[InputMedia]:
             logger.info(f"Resolving share link: {url}")
             async with httpx.AsyncClient(follow_redirects=True) as client:
                 response = await client.get(url, timeout=5)
-        url = str(response.url)
-        logger.info(f"Resolved to standard URL: {url}")
+            url = str(response.url)
+            logger.info(f"Resolved to standard URL: {url}")
 
         media_id = await asyncio.to_thread(cl.media_pk_from_url, url)
         media_info = await asyncio.to_thread(cl.media_info_v1, media_id)
@@ -44,6 +44,7 @@ async def process(url: str) -> None | list[InputMedia]:
         return media_group
     except MediaNotFound:
         logger.warning(f"No media found for url: {url}")
+        return None
     except Exception as e:
         logger.error(f"An unexpected error occurred: {e}")
         return None

--- a/services/instagram.py
+++ b/services/instagram.py
@@ -1,6 +1,8 @@
 import asyncio
 
+import httpx
 from instagrapi import Client
+from instagrapi.exceptions import MediaNotFound
 from telegram import InputMedia, InputMediaPhoto, InputMediaVideo
 
 from config import IG_SESSION_ID
@@ -15,11 +17,15 @@ async def process(url: str) -> None | list[InputMedia]:
     logger.info(f"Processing Instagram url: {url}")
 
     try:
+        if "/share/" in url:
+            logger.info(f"Resolving share link: {url}")
+            async with httpx.AsyncClient(follow_redirects=True) as client:
+                response = await client.get(url, timeout=5)
+        url = str(response.url)
+        logger.info(f"Resolved to standard URL: {url}")
+
         media_id = await asyncio.to_thread(cl.media_pk_from_url, url)
         media_info = await asyncio.to_thread(cl.media_info_v1, media_id)
-        if not media_info:
-            logger.warning(f"No media found for url: {url}")
-            return None
 
         media_type = media_info.media_type
 
@@ -36,7 +42,8 @@ async def process(url: str) -> None | list[InputMedia]:
                     else:
                         media_group.append(InputMediaVideo(str(media.video_url)))
         return media_group
-
+    except MediaNotFound:
+        logger.warning(f"No media found for url: {url}")
     except Exception as e:
         logger.error(f"An unexpected error occurred: {e}")
         return None


### PR DESCRIPTION
* Added logic to detect Instagram permalinks (URLs containing `/share/`) and resolve them to standard URLs using `httpx.AsyncClient` with redirects enabled